### PR TITLE
Use /etc/issue to check system version

### DIFF
--- a/build_centos_63.sh
+++ b/build_centos_63.sh
@@ -7,8 +7,9 @@ set -e
 ## doesn't exist.
 [ $( id -u ) -eq 0 ] || { echo "must be root"; exit 1; }
 
-OS=`lsb_release -is`
-VER=`lsb_release -rs`
+sys=($(cat /etc/issue | head -1))
+OS=${sys[0]}
+VER=${sys[2]}
 
 if [ "$OS" != "CentOS" ]; then
     echo "Needs to be run on CentOS"

--- a/build_centos_63.sh
+++ b/build_centos_63.sh
@@ -7,7 +7,12 @@ set -e
 ## doesn't exist.
 [ $( id -u ) -eq 0 ] || { echo "must be root"; exit 1; }
 
-sys=($(cat /etc/issue | head -1))
+if [ ! -f /etc/redhat-release ]; then
+    echo "Needs to be run on CentOS";
+    exit 1
+fi
+
+sys=($(cat /etc/redhat-release | head -1))
 OS=${sys[0]}
 VER=${sys[2]}
 


### PR DESCRIPTION
In small CentOS installs, `lsb_release` command is not available, so the script fails.

Instead `lsb_release`, we can use the file `/etc/issue`, which contains the same information.